### PR TITLE
Build service images with google buildpack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+# TODO: check for os version to determine the download script on setup
+
+LOCAL_REGISTRY="localhost:5000"
+
+ifeq (, $(shell docker version))
+$(error "either docker daemon is not running or docker is not installed")
+$(info "check: https://docs.docker.com/get-docker/")
+endif
+
+ifeq (, $(shell pack version))
+$(error "could not find pack installed in $(PATH)")
+$(info "check: https://buildpacks.io/docs/tools/pack/#install")
+endif
+
+ifeq (, $(shell skaffold version))
+$(error "could not find skaffold installed in $(PATH)")
+$(info "check: https://skaffold.dev/docs/install/")
+endif
+
+.PHONY: local-build
+
+default: all
+
+all: local-build
+
+local-build:
+	$(info ******************** building and pushing to local registry at $(LOCAL_REGISTRY) ********************)
+	skaffold build --default-repo $(LOCAL_REGISTRY)

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -24,18 +24,46 @@ build:
   # https://skaffold.dev/docs/concepts/#image-repository-handling
   - image: emailservice
     context: src/emailservice
+    buildpacks:
+      builder: "gcr.io/buildpacks/builder:v1"
+      env:
+      - GOOGLE_RUNTIME_VERSION=3.7.0
+      - PYTHONUNBUFFERED=1
+      - ENABLE_PROFILER=1
   - image: productcatalogservice
     context: src/productcatalogservice
+    buildpacks:
+      builder: "gcr.io/buildpacks/builder:v1"
+      env:
+      - GOTRACEBACK=single
   - image: recommendationservice
     context: src/recommendationservice
+    buildpacks:
+      builder: "gcr.io/buildpacks/builder:v1"
+      env:
+      - PORT=8080
+      - GOOGLE_RUNTIME_VERSION=3.7.0
   - image: shippingservice
     context: src/shippingservice
+    buildpacks:
+      builder: "gcr.io/buildpacks/builder:v1"
+      env:
+      - APP_PORT=50051
+      - GOTRACEBACK=single
   - image: checkoutservice
     context: src/checkoutservice
+    buildpacks:
+      builder: "gcr.io/buildpacks/builder:v1"
+      env:
+      - GOTRACEBACK=single
   - image: paymentservice
     context: src/paymentservice
+    buildpacks:
+      builder: "gcr.io/buildpacks/builder:v1"
   - image: currencyservice
     context: src/currencyservice
+    buildpacks:
+      builder: "gcr.io/buildpacks/builder:v1"
   - image: cartservice
     context: src/cartservice/src
     docker:

--- a/src/emailservice/Procfile
+++ b/src/emailservice/Procfile
@@ -1,0 +1,1 @@
+web: python email_server.py

--- a/src/recommendationservice/Procfile
+++ b/src/recommendationservice/Procfile
@@ -1,0 +1,1 @@
+web: python recommendation_server.py


### PR DESCRIPTION
### Background 
<!-- What was happening before this PR, and the problem(s) it solves -->
Initially, the service images could only use Dockerfile to build the images.

### Fixes 
<!-- Link the issue(s) this PR fixes-->
This PR update the `skaffold.yaml` configuration to use Google Buildpack for most of the services

### Change Summary
<!-- Short summary of the changes submitted -->
Update the `skaffold.yaml` configuration to use buildpack

### Additional Notes
<!-- Any remaining concerns -->
Eventually, a mix of both Docker and Google Buildpack are used for creating the images
Also, a Makefile was added to make it easy to do a local image build to a local registry
### Testing Procedure
<!-- If applicable, write how to test for reviewers-->

### Related PRs or Issues 
<!-- Dependent PRs, or any relevant linked issues -->
